### PR TITLE
Configuration changes to enable BT audio.

### DIFF
--- a/etc/pulse/arm_nokia_rm_680_board.pa
+++ b/etc/pulse/arm_nokia_rm_680_board.pa
@@ -8,11 +8,6 @@ load-module module-dbus-protocol
 ### Automatically restore the volume of streams and devices
 load-module module-stream-restore-nemo restore_device=no restore_volume=yes restore_muted=no route_table=/etc/pulse/x-maemo-route.table fallback_table=/etc/pulse/x-maemo-stream-restore.table
 
-### Automatically load driver modules for Bluetooth hardware
-.ifexists module-bluetooth-discover.so
-load-module module-bluetooth-discover
-.endif
-
 ### Automatically suspend sinks/sources that become idle for too long
 load-module module-suspend-on-idle timeout=5
 
@@ -59,7 +54,12 @@ load-module module-meego-record source_name=source.record master_source=source.v
 ### Bluetooth OMAP SCO over PCM
 .nofail
 
-load-module module-alsa-card device_id=2 rate=8000 sink_name=sink.hw1 source_name=source.hw1 profile_set=nokia-n950-wl1273.conf
+load-module module-alsa-card device_id=2 rate=8000 sink_name=sink.hw1 source_name=source.hw1 profile_set=nokia-n950-wl1273.conf tsched=0 fragment_size=80 fragments=2 format=s16le
+
+### Automatically load driver modules for Bluetooth hardware
+.ifexists module-bluetooth-discover.so
+load-module module-bluetooth-discover sco_sink=sink.hw1 sco_source=source.hw1
+.endif
 
 ### Extra modules
 .ifexists module-meego-parameters.so

--- a/usr/share/pulseaudio/alsa-mixer/profile-sets/nokia-n950-wl1273.conf
+++ b/usr/share/pulseaudio/alsa-mixer/profile-sets/nokia-n950-wl1273.conf
@@ -24,31 +24,31 @@ paths-input = nokia-n950-wl1273-input-bt
 channel-map = mono
 direction = any
 
-[Mapping output:fmtx]
-device-strings = hw:%f
-paths-output = nokia-n950-wl1273-output-fmtx
-channel-map = left,right
-direction = output
+#[Mapping output:fmtx]
+#device-strings = hw:%f
+#paths-output = nokia-n950-wl1273-output-fmtx
+#channel-map = left,right
+#direction = output
 
-[Mapping input:fmrx]
-device-strings = hw:%f
-paths-input = nokia-n950-wl1273-input-fmrx
-channel-map = left,right
-direction = input
+#[Mapping input:fmrx]
+#device-strings = hw:%f
+#paths-input = nokia-n950-wl1273-input-fmrx
+#channel-map = left,right
+#direction = input
 
 [Profile bluetooth]
 description = Bluetooth
 output-mappings = output+input:bt
 input-mappings = output+input:bt
-skip-probe = no
+skip-probe = yes
 
-[Profile fmtx]
-description = FmTx radio
-output-mappings = output:fmtx
-skip-probe = no
+#[Profile fmtx]
+#description = FmTx radio
+#output-mappings = output:fmtx
+#skip-probe = yes
 
-[Profile fmrx]
-description = FmRx radio
-input-mappings = input:fmrx
-skip-probe = no
+#[Profile fmrx]
+#description = FmRx radio
+#input-mappings = input:fmrx
+#skip-probe = yes
 


### PR DESCRIPTION
For some reason path probing fails with Bluetooth ALSA device, so
skip-probe needs to be yes. This introduces the bug that path
configurations are not created for the card, but this is not problem
currently since there is only one valid path anyway.

Also disable fmtx/fmrx for now, since they don't seem to work and
changing to either profile and restarting PulseAudio causes that the
ALSA device can't be opened with bluetooth profile.
